### PR TITLE
feat: Refactor configuration into proper NX library structure

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -72,7 +72,8 @@
       "Bash(kill:*)",
       "Bash(AIDBOX_URL=http://localhost:8081 FORM_AUTOPOPULATION_CLIENT_ID=form-auto-population-service FORM_AUTOPOPULATION_CLIENT_SECRET=Z4AnRnE9YnIH8CYfJRJm1mXDNlXl8MZ3 KAFKA_BOOTSTRAP_SERVERS=localhost:9094 npx nx serve form-auto-population-service)",
       "Bash(KAFKA_BOOTSTRAP_SERVERS= npx nx serve form-auto-population-service --skipNxCache)",
-      "Bash(AIDBOX_URL=http://localhost:8081 FORM_AUTOPOPULATION_CLIENT_ID=form-auto-population-service FORM_AUTOPOPULATION_CLIENT_SECRET=Z4AnRnE9YnIH8CYfJRJm1mXDNlXl8MZ3 KAFKA_BOOTSTRAP_SERVERS=localhost:9094 npx nx serve form-auto-population-service --skipNxCache)"
+      "Bash(AIDBOX_URL=http://localhost:8081 FORM_AUTOPOPULATION_CLIENT_ID=form-auto-population-service FORM_AUTOPOPULATION_CLIENT_SECRET=Z4AnRnE9YnIH8CYfJRJm1mXDNlXl8MZ3 KAFKA_BOOTSTRAP_SERVERS=localhost:9094 npx nx serve form-auto-population-service --skipNxCache)",
+      "Bash(npm audit:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -68,7 +68,11 @@
       "Bash(git rm:*)",
       "Bash(cat:*)",
       "Bash(pkill:*)",
-      "Bash(AIDBOX_URL=http://localhost:8081 FORM_AUTOPOPULATION_CLIENT_ID=form-auto-population-service FORM_AUTOPOPULATION_CLIENT_SECRET=Z4AnRnE9YnIH8CYfJRJm1mXDNlXl8MZ3 npx nx serve form-auto-population-service)"
+      "Bash(AIDBOX_URL=http://localhost:8081 FORM_AUTOPOPULATION_CLIENT_ID=form-auto-population-service FORM_AUTOPOPULATION_CLIENT_SECRET=Z4AnRnE9YnIH8CYfJRJm1mXDNlXl8MZ3 npx nx serve form-auto-population-service)",
+      "Bash(kill:*)",
+      "Bash(AIDBOX_URL=http://localhost:8081 FORM_AUTOPOPULATION_CLIENT_ID=form-auto-population-service FORM_AUTOPOPULATION_CLIENT_SECRET=Z4AnRnE9YnIH8CYfJRJm1mXDNlXl8MZ3 KAFKA_BOOTSTRAP_SERVERS=localhost:9094 npx nx serve form-auto-population-service)",
+      "Bash(KAFKA_BOOTSTRAP_SERVERS= npx nx serve form-auto-population-service --skipNxCache)",
+      "Bash(AIDBOX_URL=http://localhost:8081 FORM_AUTOPOPULATION_CLIENT_ID=form-auto-population-service FORM_AUTOPOPULATION_CLIENT_SECRET=Z4AnRnE9YnIH8CYfJRJm1mXDNlXl8MZ3 KAFKA_BOOTSTRAP_SERVERS=localhost:9094 npx nx serve form-auto-population-service --skipNxCache)"
     ],
     "deny": [],
     "ask": []

--- a/apps/form-auto-population-service/src/app/health.controller.spec.ts
+++ b/apps/form-auto-population-service/src/app/health.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HealthController } from './health.controller';
+import { AppConfigService } from '@form-auto-population/config';
 
 // Mock kafkajs
 vi.mock('kafkajs', () => ({
@@ -18,17 +19,32 @@ vi.mock('kafkajs', () => ({
 }));
 
 // Mock axios
-vi.mock('axios');
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ status: 200, headers: {} }),
+  },
+}));
 
 describe('HealthController', () => {
   let controller: HealthController;
+  let configService: AppConfigService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
+      providers: [
+        {
+          provide: AppConfigService,
+          useValue: {
+            kafkaBootstrapServers: 'localhost:9092',
+            fhirServerUrl: 'http://localhost:8081',
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<HealthController>(HealthController);
+    configService = module.get<AppConfigService>(AppConfigService);
   });
 
   it('should be defined', () => {
@@ -37,13 +53,13 @@ describe('HealthController', () => {
 
   describe('getHealth', () => {
     it('should return unhealthy status when services not configured', async () => {
-      // Clear environment variables for this test
-      delete process.env.KAFKA_BOOTSTRAP_SERVERS;
-      delete process.env.DATABASE_URL;
-      delete process.env.DB_HOST;
-      delete process.env.DB_PORT;
-      delete process.env.FHIR_SERVER_URL;
-      delete process.env.AIDBOX_URL;
+      // Mock config service to return undefined for required services
+      vi.spyOn(configService, 'kafkaBootstrapServers', 'get').mockReturnValue(
+        undefined as any
+      );
+      vi.spyOn(configService, 'fhirServerUrl', 'get').mockReturnValue(
+        undefined as any
+      );
 
       const result = await controller.getHealth();
 
@@ -53,45 +69,51 @@ describe('HealthController', () => {
         service: 'form-auto-population-service',
         version: '1.0.0',
         checks: {
-          kafka: 'not-configured',
-          database: 'not-configured',
-          externalApi: 'not-configured',
+          kafka: {
+            status: 'not-configured',
+            brokers: [],
+            required: true,
+          },
+          fhirServer: {
+            status: 'not-configured',
+            error: 'AIDBOX_URL environment variable not configured',
+            required: true,
+          },
         },
         uptime: expect.any(Number),
-        required: ['kafka', 'externalApi'],
-        optional: ['database'],
+        required: ['kafka', 'fhirServer'],
       });
     });
 
     it('should check Kafka connection when configured', async () => {
-      // Set environment variables for this test
-      process.env.KAFKA_BOOTSTRAP_SERVERS = 'localhost:9092';
-      process.env.AIDBOX_URL = 'http://localhost:8081';
+      // Config service already has default values configured
 
       const result = await controller.getHealth();
 
-      expect(result.checks.kafka).toBe('connected');
-      // Status will still be unhealthy because FHIR server is mocked as unavailable
-      expect(result.status).toBe('unhealthy');
-
-      // Clean up
-      delete process.env.KAFKA_BOOTSTRAP_SERVERS;
-      delete process.env.AIDBOX_URL;
+      expect(result.checks.kafka.status).toBe('connected');
+      expect(result.checks.kafka.brokers).toEqual(['localhost:9092']);
+      expect(result.checks.kafka.required).toBe(true);
     });
 
-    it('should check database configuration when set', async () => {
-      // Set environment variables for this test
-      process.env.DB_HOST = 'localhost';
-      process.env.DB_PORT = '5432';
+    it('should check FHIR server connection when configured', async () => {
+      // Config service already has default values configured
 
       const result = await controller.getHealth();
 
-      expect(result.checks.database).toBe('configured');
-      expect(result.status).toBe('unhealthy'); // Still unhealthy because Kafka and FHIR are not configured
+      expect(result.checks.fhirServer.status).toBe('connected');
+      expect(result.checks.fhirServer.url).toBe('http://localhost:8081');
+      expect(result.checks.fhirServer.required).toBe(true);
+      expect(result.checks.fhirServer.lastChecked).toEqual(expect.any(String));
+    });
 
-      // Clean up
-      delete process.env.DB_HOST;
-      delete process.env.DB_PORT;
+    it('should return healthy status when all required services are connected', async () => {
+      // Config service already has default values configured
+
+      const result = await controller.getHealth();
+
+      expect(result.status).toBe('ok');
+      expect(result.checks.kafka.status).toBe('connected');
+      expect(result.checks.fhirServer.status).toBe('connected');
     });
   });
 });

--- a/apps/form-auto-population-service/vite.config.ts
+++ b/apps/form-auto-population-service/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
         __dirname,
         '../../libs/fhir-client/src/index.ts'
       ),
+      '@form-auto-population/config': resolve(
+        __dirname,
+        '../../libs/config/src/index.ts'
+      ),
     },
   },
   test: {

--- a/libs/config/package.json
+++ b/libs/config/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@form-auto-population/config",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0"
+  }
+}

--- a/libs/config/project.json
+++ b/libs/config/project.json
@@ -1,0 +1,43 @@
+{
+  "name": "config",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/config/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/config",
+        "main": "libs/config/src/index.ts",
+        "tsConfig": "libs/config/tsconfig.lib.json",
+        "assets": ["libs/config/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/config/**/*.{ts,tsx,js,jsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {}
+    },
+    "format": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "prettier --write \"libs/config/**/*.{js,ts,json,md}\""
+      }
+    },
+    "format:check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "prettier --check \"libs/config/**/*.{js,ts,json,md}\""
+      }
+    }
+  },
+  "tags": ["type:lib", "scope:shared"]
+}

--- a/libs/config/src/index.ts
+++ b/libs/config/src/index.ts
@@ -1,0 +1,3 @@
+export * from './lib/config';
+export * from './lib/config.schema';
+export * from './lib/config.module';

--- a/libs/config/src/lib/config.module.ts
+++ b/libs/config/src/lib/config.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AppConfigService, configFactory } from './config';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [configFactory],
+      envFilePath: ['.env.local', '.env'],
+      expandVariables: true,
+    }),
+  ],
+  providers: [AppConfigService],
+  exports: [AppConfigService],
+})
+export class AppConfigModule {}

--- a/libs/config/src/lib/config.schema.ts
+++ b/libs/config/src/lib/config.schema.ts
@@ -5,38 +5,70 @@ import {
   IsUrl,
   IsOptional,
   ValidateNested,
+  IsNotEmpty,
 } from 'class-validator';
 
 export class KafkaConfig {
-  @IsString()
+  @IsNotEmpty({
+    message:
+      'KAFKA_BOOTSTRAP_SERVERS is required. Please set this environment variable.',
+  })
+  @IsString({ message: 'KAFKA_BOOTSTRAP_SERVERS must be a valid string.' })
   bootstrapServers!: string;
 
-  @IsString()
+  @IsNotEmpty({
+    message:
+      'KAFKA_CLIENT_ID is required. Please set this environment variable.',
+  })
+  @IsString({ message: 'KAFKA_CLIENT_ID must be a valid string.' })
   clientId!: string;
 
   @IsOptional()
-  @IsNumber()
+  @IsNumber({}, { message: 'KAFKA_CONNECTION_TIMEOUT must be a valid number.' })
   connectionTimeout?: number;
 
   @IsOptional()
-  @IsNumber()
+  @IsNumber({}, { message: 'KAFKA_REQUEST_TIMEOUT must be a valid number.' })
   requestTimeout?: number;
 
-  @IsString()
+  @IsNotEmpty({
+    message:
+      'FORM_POPULATION_COMPLETED_TOPIC is required. Please set this environment variable.',
+  })
+  @IsString({
+    message: 'FORM_POPULATION_COMPLETED_TOPIC must be a valid string.',
+  })
   formPopulationCompletedTopic!: string;
 }
 
 export class FhirServerConfig {
-  @IsUrl()
+  @IsNotEmpty({
+    message:
+      'AIDBOX_URL is required. Please set this environment variable to your FHIR server URL.',
+  })
+  @IsUrl(
+    {},
+    { message: 'AIDBOX_URL must be a valid URL (e.g., http://localhost:8081).' }
+  )
   url!: string;
 
-  @IsOptional()
-  @IsString()
-  clientId?: string;
+  @IsNotEmpty({
+    message:
+      'FORM_AUTOPOPULATION_CLIENT_ID is required. Please set this environment variable.',
+  })
+  @IsString({
+    message: 'FORM_AUTOPOPULATION_CLIENT_ID must be a valid string.',
+  })
+  clientId!: string;
 
-  @IsOptional()
-  @IsString()
-  clientSecret?: string;
+  @IsNotEmpty({
+    message:
+      'FORM_AUTOPOPULATION_CLIENT_SECRET is required. Please set this environment variable.',
+  })
+  @IsString({
+    message: 'FORM_AUTOPOPULATION_CLIENT_SECRET must be a valid string.',
+  })
+  clientSecret!: string;
 }
 
 export class AppConfig {

--- a/libs/config/src/lib/config.schema.ts
+++ b/libs/config/src/lib/config.schema.ts
@@ -1,0 +1,68 @@
+import { Type } from 'class-transformer';
+import {
+  IsString,
+  IsNumber,
+  IsUrl,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+
+export class KafkaConfig {
+  @IsString()
+  bootstrapServers!: string;
+
+  @IsString()
+  clientId!: string;
+
+  @IsOptional()
+  @IsNumber()
+  connectionTimeout?: number;
+
+  @IsOptional()
+  @IsNumber()
+  requestTimeout?: number;
+
+  @IsString()
+  formPopulationCompletedTopic!: string;
+}
+
+export class FhirServerConfig {
+  @IsUrl()
+  url!: string;
+
+  @IsOptional()
+  @IsString()
+  clientId?: string;
+
+  @IsOptional()
+  @IsString()
+  clientSecret?: string;
+}
+
+export class AppConfig {
+  @IsOptional()
+  @IsString()
+  nodeEnv?: string;
+
+  @IsOptional()
+  @IsNumber()
+  port?: number;
+
+  @IsOptional()
+  @IsString()
+  corsOrigin?: string;
+}
+
+export class Config {
+  @ValidateNested()
+  @Type(() => AppConfig)
+  app!: AppConfig;
+
+  @ValidateNested()
+  @Type(() => KafkaConfig)
+  kafka!: KafkaConfig;
+
+  @ValidateNested()
+  @Type(() => FhirServerConfig)
+  fhirServer!: FhirServerConfig;
+}

--- a/libs/config/src/lib/config.ts
+++ b/libs/config/src/lib/config.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import {
+  Config,
+  AppConfig,
+  KafkaConfig,
+  FhirServerConfig,
+} from './config.schema';
+
+export function configFactory(): Config {
+  const rawConfig = {
+    app: {
+      nodeEnv: process.env.NODE_ENV || 'development',
+      port: process.env.PORT ? parseInt(process.env.PORT, 10) : 3000,
+      corsOrigin:
+        process.env.CORS_ORIGIN ||
+        'http://localhost:3000,http://localhost:4200',
+    },
+    kafka: {
+      bootstrapServers: process.env.KAFKA_BOOTSTRAP_SERVERS || 'localhost:9094',
+      clientId: process.env.KAFKA_CLIENT_ID || 'form-population-service',
+      connectionTimeout: process.env.KAFKA_CONNECTION_TIMEOUT
+        ? parseInt(process.env.KAFKA_CONNECTION_TIMEOUT, 10)
+        : 30000,
+      requestTimeout: process.env.KAFKA_REQUEST_TIMEOUT
+        ? parseInt(process.env.KAFKA_REQUEST_TIMEOUT, 10)
+        : 30000,
+      formPopulationCompletedTopic:
+        process.env.FORM_POPULATION_COMPLETED_TOPIC ||
+        'form.population.completed',
+    },
+    fhirServer: {
+      url: process.env.AIDBOX_URL || 'http://localhost:8081',
+      clientId: process.env.FORM_AUTOPOPULATION_CLIENT_ID,
+      clientSecret: process.env.FORM_AUTOPOPULATION_CLIENT_SECRET,
+    },
+  };
+
+  const config = plainToInstance(Config, rawConfig, {
+    enableImplicitConversion: true,
+  });
+
+  const errors = validateSync(config, {
+    skipMissingProperties: false,
+  });
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Configuration validation error: ${errors
+        .map((error) => Object.values(error.constraints || {}).join(', '))
+        .join('; ')}`
+    );
+  }
+
+  return config;
+}
+
+@Injectable()
+export class AppConfigService {
+  constructor(private configService: ConfigService<Config, true>) {}
+
+  get app(): AppConfig {
+    return this.configService.get('app', { infer: true });
+  }
+
+  get kafka(): KafkaConfig {
+    return this.configService.get('kafka', { infer: true });
+  }
+
+  get fhirServer(): FhirServerConfig {
+    return this.configService.get('fhirServer', { infer: true });
+  }
+
+  get port(): number {
+    return this.app.port || 3000;
+  }
+
+  get nodeEnv(): string {
+    return this.app.nodeEnv || 'development';
+  }
+
+  get isDevelopment(): boolean {
+    return this.nodeEnv === 'development';
+  }
+
+  get isProduction(): boolean {
+    return this.nodeEnv === 'production';
+  }
+
+  get kafkaBootstrapServers(): string {
+    return this.kafka.bootstrapServers;
+  }
+
+  get kafkaClientId(): string {
+    return this.kafka.clientId;
+  }
+
+  get fhirServerUrl(): string {
+    return this.fhirServer.url;
+  }
+
+  get formPopulationCompletedTopic(): string {
+    return this.kafka.formPopulationCompletedTopic;
+  }
+}

--- a/libs/config/src/lib/config.ts
+++ b/libs/config/src/lib/config.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { plainToInstance } from 'class-transformer';
-import { validateSync } from 'class-validator';
+import { validateSync, ValidationError } from 'class-validator';
 import {
   Config,
   AppConfig,
@@ -45,7 +45,7 @@ export function configFactory(): Config {
   });
 
   if (errors.length > 0) {
-    const formatErrors = (errors: any[], prefix = ''): string[] => {
+    const formatErrors = (errors: ValidationError[], prefix = ''): string[] => {
       const messages: string[] = [];
 
       for (const error of errors) {

--- a/libs/config/tsconfig.json
+++ b/libs/config/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "declarationMap": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/config/tsconfig.lib.json
+++ b/libs/config/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/libs/config",
+    "declaration": true,
+    "types": ["node"],
+    "emitDeclarationOnly": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@form-auto-population/config": ["libs/config/src/index.ts"],
       "@form-auto-population/fhir-client": ["libs/fhir-client/src/index.ts"],
       "@form-auto-population/fhir-converters": [
         "libs/fhir-converters/src/index.ts"


### PR DESCRIPTION
## Summary

This PR refactors the configuration system from ad-hoc structure into a proper NX library following workspace patterns and NestJS best practices.

### Key Changes

- **New `@form-auto-population/config` library** following NX patterns with proper project.json, package.json, and TypeScript configuration
- **Generic FHIR server terminology** replacing Aidbox-specific naming while maintaining backward compatibility
- **Type-safe configuration** using class-transformer and class-validator for validation
- **NestJS best practices** with proper module structure and dependency injection
- **Comprehensive AppConfigService** with typed getters for all configuration sections

### Technical Details

#### Library Structure
```
libs/config/
├── project.json          # NX project configuration
├── package.json          # Library dependencies
├── tsconfig.json         # TypeScript configuration
├── tsconfig.lib.json     # Library-specific TypeScript config
└── src/
    ├── index.ts          # Public API exports
    └── lib/
        ├── config.ts      # AppConfigService and configFactory
        ├── config.schema.ts # Configuration classes with validation
        └── config.module.ts # NestJS module configuration
```

#### Configuration Features
- **Validation**: All configuration validated at startup using class-validator
- **Type Safety**: Fully typed configuration with IntelliSense support
- **Environment Variables**: Backward compatible with existing env vars (`AIDBOX_URL`, etc.)
- **Default Values**: Sensible defaults for development environment
- **Module Pattern**: Follows NestJS ConfigModule patterns

#### Terminology Updates
- `AidboxConfig` → `FhirServerConfig`
- `aidbox` properties → `fhirServer` properties
- Generic "FHIR server" terminology throughout codebase
- Environment variable names unchanged for compatibility

### Backward Compatibility

✅ **All existing environment variables work unchanged:**
- `AIDBOX_URL`
- `FORM_AUTOPOPULATION_CLIENT_ID`
- `FORM_AUTOPOPULATION_CLIENT_SECRET`
- `KAFKA_BOOTSTRAP_SERVERS`
- All other existing variables

### Testing

- [x] Health endpoint works correctly with new configuration
- [x] Service starts successfully with existing .env files
- [x] All configuration validation works as expected
- [x] Import path `@form-auto-population/config` resolves correctly

## Test Plan

- [ ] Verify service starts with existing environment configuration
- [ ] Confirm health endpoint returns correct status
- [ ] Test configuration validation with invalid values
- [ ] Check TypeScript compilation and imports
- [ ] Validate NX build and lint targets work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)